### PR TITLE
fix bug:balance is not reduce when BTC lockout:call lockout,tx is not confirmed and call dcrm transaction

### DIFF
--- a/crypto/dcrm/btc_tx.go
+++ b/crypto/dcrm/btc_tx.go
@@ -1007,7 +1007,7 @@ func (s sortableLURSlice) Len() int {
 }
 
 func (s sortableLURSlice) Less(i, j int) bool {
-	return s[i].Amount > s[j].Amount
+	return s[i].Amount <= s[j].Amount
 }
 
 func (s sortableLURSlice) Swap(i, j int) {

--- a/crypto/dcrm/fusion_dcrm.go
+++ b/crypto/dcrm/fusion_dcrm.go
@@ -1146,7 +1146,7 @@ func SendReqToGroup(msg string,rpctype string) (string,error) {
     }
 
     var t int
-    if rpctype == "rpc_lockout" {
+    if rpctype == "rpc_lockout" || rpctype == "rpc_lockin" {
 	t = 360
     } else {
 	t = 80 


### PR DESCRIPTION
fix bug:balance is not reduce when BTC lockout:call lockout,tx is not confirmed and call dcrm transaction